### PR TITLE
Added binary configuration option to choose a non-vendored binary

### DIFF
--- a/lib/xhyve/guest.rb
+++ b/lib/xhyve/guest.rb
@@ -27,6 +27,7 @@ module Xhyve
       @acpi = opts[:acpi] || true
       @networking = opts[:networking] || true
       @foreground = opts[:foreground] || false
+      @binary = opts[:binary] || BINARY_PATH
       @command = build_command
       @mac = find_mac
     end
@@ -70,7 +71,7 @@ module Xhyve
 
     def build_command
       [
-        "#{BINARY_PATH}",
+        "#{@binary}",
         "#{'-A' if @acpi}",
         '-U', @uuid,
         '-m', @memory,


### PR DESCRIPTION
Pretty self explanatory. I often am interested in using a custom build of xhyve so not having to use the bundled xhyve binary would be nice.
